### PR TITLE
Fix: Move default binary generation log file path from converter path to build path

### DIFF
--- a/tools/qnn_converter/generate_binary.py
+++ b/tools/qnn_converter/generate_binary.py
@@ -32,6 +32,7 @@ for graph in graph_names:
 backend_path = qnn_sdk_folder / "lib" / "x86_64-linux-clang" / "libQnnHtp.so"
 htp_setting_path = build_folder / "htp_setting.json"
 htp_config_path = build_folder / "htp_config.json"
+log_path = build_folder / args.log_file
 
 log_file = open(args.log_file, "w")
 


### PR DESCRIPTION
Currently the default log file path is in the converter directory, which may be easily ignored.

Modified file: tools/qnn_converter/generate_binary.py