### PR TITLE
Make --n-threads arg work consistently in different model conversion phases

### DIFF
--- a/tools/qnn_converter/build_all_layers.py
+++ b/tools/qnn_converter/build_all_layers.py
@@ -13,6 +13,7 @@ parser.add_argument("--n-model-chunks", type=int, required=True)
 parser.add_argument("--artifact-name", type=str, required=True)
 parser.add_argument("--graph-names", type=str, nargs="+", required=True)
 parser.add_argument("--soc", choices=soc_map.keys(), default="8gen3")
+parser.add_argument("--n-threads", type=int, required=True)
 args = parser.parse_args()
 
 
@@ -80,7 +81,7 @@ def build_binary(chunk_id: int):
 
 
 multiprocessing.Process()
-pool = multiprocessing.Pool(args.n_model_chunks if args.n_model_chunks < 16 else 16)
+pool = multiprocessing.Pool(args.n_model_chunks if args.n_model_chunks < args.n_threads else args.n_threads)
 chunk_ids = list(range(args.n_model_chunks))
 chunk_ids.insert(0, -1)
 if args.batch_size == -1:

--- a/tools/qnn_converter/converter.py
+++ b/tools/qnn_converter/converter.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         description="Convert the model in safetensors format to a QNN executable binary format."
     )
 
-    parser.add_argument("--n-threads", type=int, default=24, help="Number of threads to use when exporting to onnx.")
+    parser.add_argument("--n-threads", type=int, default=24, help="Number of threads to use when exporting the model.")
     parser.add_argument("--model-folder", type=str, help="Model folder path.", required=True)
     parser.add_argument("--model-name", type=str, help="Model name.", required=True)
     parser.add_argument(

--- a/tools/qnn_converter/converter.py
+++ b/tools/qnn_converter/converter.py
@@ -79,7 +79,8 @@ def main(args):
             --batch-size {i} \
             --n-model-chunks {args.n_model_chunks} \
             --artifact-name {args.artifact_name} \
-            --graph-names batch_{i}
+            --graph-names batch_{i} \ 
+            --n-threads {args.n_threads}
         """
         run_shell_command(generate_so_command)
 


### PR DESCRIPTION
Previously model converter works in n threads in onnx export phase but runs on maximum parallel in binary generation phase, which may cause unintended OOM and convert fails with no error report.

This PR makes --n-threads cmdline arg work consistently in both phases, with at max n threads.